### PR TITLE
Generalise

### DIFF
--- a/docs/events/events.md
+++ b/docs/events/events.md
@@ -1,0 +1,3 @@
+# Research Computing Events at Northumbria
+
+Watch this space!

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -56,7 +56,7 @@ markdown_extensions:
 nav:
   - Home: index.md
 
-  - Quickstart:
+  - Oswald Quickstart:
     - Accessing Oswald: quickstart/accessing-oswald.md
     - Storage and Filesystems: quickstart/storage-and-filesystems.md
     - Software Environment and Modules: quickstart/software-environment.md
@@ -64,13 +64,15 @@ nav:
     - Using Specialised Nodes: quickstart/using-specialised-nodes.md
     - Application Development Tools: quickstart/application-development-tools.md
 
-  - Software:
+  - Oswald Software:
     - Software List: software/software-list.md
     - MPI: software/mpi.md
     - GNU Compilers: software/gnu-compilers.md
     - Intel Compilers: software/intel-compilers.md
 
-  - Support:
+  - Oswald Support:
     - University Support: support/university-support.md
     - FAQs: support/faqs.md
     - Known Issues: support/known-issues.md
+    
+  - Events: events/events.md

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -1,9 +1,9 @@
-site_name: Oswald User Documentation and Newsletter
-site_description: Documentation and newsletter for Northumbria University's Oswald HPC cluster (supercomputer)
+site_name: Northumbria University Research Computing Community
+site_description: Documentation, events and newsletter for Northumbria University's Research Computing Community
 
-site_url: https://nu-cem.github.io/HPC_internship_2021 # Needed for rss-plugin
-repo_url: https://github.com/musicmrman99/HPC_Internship_2021 # Change this later
-repo_name: NU-CEM/oswald-docs
+site_url: https://rsc-northumbria.github.io/oswald-docs/ # Needed for rss-plugin
+repo_url: https://github.com/RSC-Northumbria/oswald-docs 
+repo_name: RSC-Northumbria/oswald-docs
 edit_uri: edit/main/docs/
 
 plugins:
@@ -12,7 +12,7 @@ plugins:
       enable_creation_date: true
   - rss:
       abstract_chars_count: 10000 # Probably the whole newsletter, but truncate if quite long
-      image: https://nu-cem.github.io/HPC_internship_2021/assets/images/logo.png
+      image: https://rsc-northumbria.github.io/oswald-docs/assets/images/logo.png
       match_path: "newsletter/.*"
       pretty_print: true
 


### PR DESCRIPTION
Generalise site so it's more broadly about research computing at Northumbria. This is partly as the newsletter is for research computing more generally (not just Oswald specific). We could have two separate sites in the future but for now lets keep it all in one place. 